### PR TITLE
fix: Better stopping condition

### DIFF
--- a/src/JultraDark.jl
+++ b/src/JultraDark.jl
@@ -119,7 +119,7 @@ function evolve_to!(t_start, t_end, grids, output_config, config::Config.Simulat
 
     t = t_start
 
-    while ~(t >= t_end)
+    while ~(t >= t_end || t ≈ t_end)
         Δt, n_steps = actual_time_step(
             max_time_step(grids, config.a(t)),
             t_end - t,


### PR DESCRIPTION
Stop when the time is approximately equal to the end time.