### PR TITLE
fix: gravitational timestep

### DIFF
--- a/src/JultraDark.jl
+++ b/src/JultraDark.jl
@@ -25,7 +25,7 @@ const PHASE_GRAD_LIMIT = π / 4
 Calculate an upper bound on the time step
 """
 function max_time_step(grids, a)
-    max_time_step_gravity = 2π / maximum(grids.Φx)
+    max_time_step_gravity = 2π / maximum(abs.(grids.Φx))
     max_time_step_pressure = 2π * 2 / maximum(grids.k)^2 * a^2  # TODO: cache k_max
 
     @assert isfinite(max_time_step_gravity)


### PR DESCRIPTION
The gravitational part of the time step should always be positive but
becomes negative when the gravitational potential is negative.  This can
happen if a sufficiently large fixed background potential is added.

This part of the time step should be such that the phase at any point
never changes by pi during a given time step.  A negative potential
would change the phase in the opposite direction, so should be taken
into account.

Add an absolute value to the time step.

Fixes #31