### PR TITLE
feat: Add position arrays to Grids

### DIFF
--- a/src/pencil_grids.jl
+++ b/src/pencil_grids.jl
@@ -193,3 +193,17 @@ function PencilGrids(ψx::Array{Complex{Float64}}, length::Real)::PencilGrids
     grids
 
 end
+
+function dist_array(length, resol::Integer)
+    gridvec = range(
+        -length / 2 + length / 2resol,
+        +length / 2 - length / 2resol,
+        length=resol
+    )
+
+    x = reshape(gridvec, resol, 1, 1)
+    y = reshape(gridvec, 1, resol, 1)
+    z = reshape(gridvec, 1, 1, resol)
+
+    (x.^2 .+ y.^2 .+ z.^2).^0.5
+end


### PR DESCRIPTION
It is often useful to have arrays of coordinates.

Add arrays of position to Grids.  Each is a 1 x 1 x resol array, so this
doesn't use much more memory.