### PR TITLE
ci: Update to julia 1.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,7 @@
 # Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
-  - julia_version: 1.4
-  - julia_version: 1.5
-  - julia_version: nightly
+  - julia_version: 1.6
 platform:
   - x86
   - x64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@ freebsd_instance:
 task:
   name: FreeBSD
   env:
-    JULIA_VERSION: 1.4
     JULIA_VERSION: 1.5
+    JULIA_VERSION: 1.6
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
   build_script:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
           - '1.5'
+          - '1.6'
           # - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Julia version 1.6 has been released, so test against that.

Also:
- drop 1.4 in github action
- drop 1.4, 1.5, nightly in appveyor