### PR TITLE
opt: Remove dist from grids structs

### DIFF
--- a/src/grids.jl
+++ b/src/grids.jl
@@ -22,8 +22,6 @@ struct Grids
     y::Array{Float64,3}
     "Array of z positions"
     z::Array{Float64,3}
-    "Real space distance array"
-    dist::Array{Float64,3}
     "Fourier space postition array"
     k::Array{Float64,3}
     "Fourier space postition array for use with `rfft`"
@@ -43,15 +41,15 @@ struct Grids
     fft_plan
     rfft_plan
 
-    function Grids(x, y, z, dist, k, rk, ψx, ψk, ρx, ρk, Φx, Φk)
+    function Grids(x, y, z, k, rk, ψx, ψk, ρx, ρk, Φx, Φk)
         n_dims = 3
-        resol_tuple = size(dist)
-        resol_tuple_realfft = (size(dist, 1) ÷ 2 + 1, size(dist, 2), size(dist, 3))
+        resol_tuple = (size(x)[1], size(y)[2], size(z)[3])
+        resol_tuple_realfft = (size(x)[1] ÷ 2 + 1, size(y)[2], size(z)[3])
 
-        for var in [dist, x, y, z, k, rk, ψx, ψk, ρx, ρk, Φx, Φk]
+        for var in [x, y, z, k, rk, ψx, ψk, ρx, ρk, Φx, Φk]
             @assert(ndims(var) == n_dims)
         end
-        for var in [dist, k, ψx, ψk, ρx, Φx]
+        for var in [k, ψx, ψk, ρx, Φx]
             @assert(size(var) == resol_tuple)
         end
         for var in [rk, ρk, Φk]
@@ -74,7 +72,7 @@ struct Grids
         )
         inv(rfft_plan)
 
-        new(x, y, z, dist, k, rk, ψx, ψk, ρx, ρk, Φx, Φk, fft_plan, rfft_plan)
+        new(x, y, z, k, rk, ψx, ψk, ρx, ρk, Φx, Φk, fft_plan, rfft_plan)
     end
 end
 
@@ -120,7 +118,6 @@ function Grids(length::Real, resol::Integer)::Grids
 
     Grids(
         x, y, z,
-        (x.^2 .+ y.^2 .+ z.^2).^0.5,
         k_norm((length, length, length), (resol, resol, resol)),
         rk_norm((length, length, length), (resol, resol, resol)),
         ψx,

--- a/test/evolution.jl
+++ b/test/evolution.jl
@@ -33,7 +33,7 @@ for grid_type in [Grids, PencilGrids]
         grids = grid_type(1.0, 16)
 
         a = 1
-        grids.ψx .= grids.dist ./ 1e9 # Set ψx to something non-zero
+        grids.ψx .= (grids.x.^2 .+ grids.y.^2 .+ grids.z.^2).^0.5 ./ 1e9 # Set ψx to something non-zero
         grids.ψk .= (grids.fft_plan * grids.ψx)
         grids.ρx .= abs2.(grids.ψx)
         grids.Φk .= -4 * π * (grids.rfft_plan * grids.ρx) ./ (a * grids.rk.^2)

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -21,16 +21,16 @@ end
     grids = Grids(1.0, resol)
     pencil_grids = PencilGrids(1.0, resol)
 
-    gathered_pg = PencilFFTs.gather(pencil_grids.dist)
+    gathered_pg = PencilFFTs.gather(pencil_grids.k)
 
     if MPI.Comm_rank(pencil_grids.MPI_COMM) == 0
-        @test all(grids.dist .== gathered_pg)
+        @test all(grids.k .== gathered_pg)
 
-        npzwrite(dir * "/dist_grids.npy", grids.dist)
+        npzwrite(joinpath(dir, "k_grids.npy"), grids.k)
 
-        npzwrite(dir * "/dist_pencilgrids.npy", gathered_pg)
+        npzwrite(joinpath(dir, "k_pencilgrids.npy"), gathered_pg)
 
-        @test all(npzread(dir * "/dist_grids.npy") .== npzread(dir * "/dist_pencilgrids.npy"))
+        @test all(npzread(joinpath(dir, "k_grids.npy")) .== npzread(joinpath(dir, "k_pencilgrids.npy")))
     else
         @test size(gathered_pg) == 0
     end

--- a/test/sims/full.jl
+++ b/test/sims/full.jl
@@ -13,6 +13,6 @@ options = Config.SimulationConfig(10, t->1)
 
 for grid_type in [Grids, PencilGrids]
     grids = grid_type(1.0, 16)
-    grids.ψx .= grids.dist ./ 1e9 # Set ψx to something non-zero
+    grids.ψx .= (grids.x.^2 .+ grids.y.^2 .+ grids.z.^2).^0.5 ./ 1e9 # Set ψx to something non-zero
     @test simulate(grids, options, output_config) == nothing
 end


### PR DESCRIPTION
Remove the dist array from `Grids` and `PencilGrids`.  This array isn't
needed for anything internal and is a waste of memory.  Using the
position arrays is more practical for anything anyway.